### PR TITLE
Fix MO2 compatibility, mod variants, and Root Builder layout

### DIFF
--- a/src/mod_manager_lib/core/instance/mod.py
+++ b/src/mod_manager_lib/core/instance/mod.py
@@ -42,6 +42,11 @@ class Mod(BaseModel):
     Metadata of the mod.
     """
 
+    variant: Optional[str] = None
+    """
+    Optional installation variant when multiple mods originate from the same archive.
+    """
+
     installed: bool
     """
     If the mod is installed. When migrating, this also indicates whether the mod is
@@ -131,6 +136,7 @@ class Mod(BaseModel):
             path=mod.path,
             deploy_path=mod.deploy_path,
             metadata=mod.metadata,
+            variant=mod.variant,
             installed=mod.installed,
             enabled=mod.enabled,
             mod_type=mod.mod_type,

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -874,6 +874,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         mod_folder: Path
         regular_deployment: bool = True
+        root_builder_deployment: bool = False
 
         if mod.mod_type in [Mod.Type.Regular, Mod.Type.Separator]:
             mod_name: str = mod.display_name
@@ -883,7 +884,10 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             meta_ini_path: Path = mod_folder / "meta.ini"
             if mod.deploy_path is not None and mod.deploy_path == Path("."):
                 if instance_data.use_root_builder:
-                    mod_folder /= "Root"
+                    root_builder_deployment = True
+                    file_redirects = ModOrganizer.__get_root_builder_redirects(
+                        mod, file_redirects, instance_data.game.mods_folder
+                    )
                 else:
                     mod_folder = instance.game_folder
                     regular_deployment = False
@@ -928,7 +932,12 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         # Append .mohidden suffix to files in mod.file_conflicts
         for file in mod.file_conflicts:
-            src: Path = mod_folder / file
+            conflict_path: Path = Path(file)
+            if root_builder_deployment:
+                conflict_path = ModOrganizer.__get_root_builder_path(
+                    conflict_path, instance_data.game.mods_folder
+                )
+            src: Path = mod_folder / conflict_path
             dst: Path = src.with_suffix(src.suffix + ".mohidden")
             os.rename(src, dst)
             self.log.debug(
@@ -947,6 +956,41 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             new_mod: Mod = Mod.create_copy(mod)
             new_mod.path = mod_folder
             instance.mods.append(new_mod)
+
+    @staticmethod
+    def __get_root_builder_redirects(
+        mod: Mod, file_redirects: dict[Path, Path], mods_folder: Path
+    ) -> dict[Path, Path]:
+        """Builds redirects for the directory layout expected by Root Builder."""
+
+        redirects: dict[Path, Path] = {}
+        for file in mod.files:
+            actual_path: Path = file_redirects.get(file, file)
+            redirects[file] = ModOrganizer.__get_root_builder_path(
+                actual_path, mods_folder
+            )
+
+        return redirects
+
+    @staticmethod
+    def __get_root_builder_path(file: Path, mods_folder: Path) -> Path:
+        """Places game mod files at the mod root and all other files under Root."""
+
+        # meta.ini describes the MO2 mod and must not be deployed into the game.
+        if len(file.parts) == 1 and file.name.casefold() == "meta.ini":
+            return file
+
+        mods_folder_parts: tuple[str, ...] = mods_folder.parts
+        if not mods_folder_parts:
+            return file
+
+        file_prefix: tuple[str, ...] = file.parts[: len(mods_folder_parts)]
+        if tuple(part.casefold() for part in file_prefix) == tuple(
+            part.casefold() for part in mods_folder_parts
+        ):
+            return Path(*file.parts[len(mods_folder_parts) :])
+
+        return Path("Root") / file
 
     @staticmethod
     def write_meta_ini_file(

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -5,9 +5,10 @@ Copyright (c) Cutleast
 import os
 import re
 import time
+from collections.abc import Mapping
 from copy import copy
 from pathlib import Path
-from typing import Any, Optional, final, override
+from typing import Any, Optional, TypeVar, final, override
 
 from cutleast_core_lib.core.downloader import Downloader
 from cutleast_core_lib.core.filesystem.archive import Archive
@@ -38,6 +39,28 @@ from mod_manager_lib.core.utilities.filesystem import clean_fs_string
 
 from ..mod_manager import ModManager
 from .instance_info import MO2InstanceInfo
+
+
+MappingValueType = TypeVar("MappingValueType")
+
+
+def _get_case_insensitive(
+    mapping: Mapping[str, MappingValueType], key: str
+) -> Optional[MappingValueType]:
+    """Returns a mapping value without requiring an exact key case match."""
+
+    folded_key: str = key.casefold()
+    return next(
+        (value for name, value in mapping.items() if name.casefold() == folded_key),
+        None,
+    )
+
+
+def _get_case_insensitive_key(mapping: Mapping[str, object], key: str) -> Optional[str]:
+    """Returns the existing spelling of a mapping key, if present."""
+
+    folded_key: str = key.casefold()
+    return next((name for name in mapping if name.casefold() == folded_key), None)
 
 
 @final
@@ -78,10 +101,15 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         if self.appdata_path.is_dir():
             for instance_ini in self.appdata_path.glob("**/ModOrganizer.ini"):
                 instance_data: IniData = IniFile.load(instance_ini)
-                if "General" not in instance_data:
+                general: Optional[dict[str, IniValue]] = _get_case_insensitive(
+                    instance_data, "General"
+                )
+                if general is None:
                     continue
 
-                instance_game: str = str(instance_data["General"].get("gameName", ""))
+                instance_game: str = str(
+                    _get_case_insensitive(general, "gameName") or ""
+                )
                 if instance_game.lower() == game.display_name.lower():
                     instances.append(instance_ini.parent.name)
 
@@ -115,9 +143,14 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             raise InstanceNotFoundError(f"{instance_name} > {profile_name}")
 
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
-        raw_game_folder: IniValue = mo2_ini_data.get("General", {}).get("gamePath")
+        general: dict[str, IniValue] = (
+            _get_case_insensitive(mo2_ini_data, "General") or {}
+        )
+        raw_game_folder: IniValue = _get_case_insensitive(general, "gamePath")
         if isinstance(raw_game_folder, str):
-            raw_game_folder = ModOrganizer.BYTE_ARRAY_PATTERN.sub(r"\1", raw_game_folder)
+            raw_game_folder = ModOrganizer.BYTE_ARRAY_PATTERN.sub(
+                r"\1", raw_game_folder
+            )
             raw_game_folder = raw_game_folder.replace("\\\\", "\\")
             game_folder = Path(raw_game_folder)
         elif game_folder is None:
@@ -158,8 +191,11 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             instance_data, mods, game_folder, file_blacklist, update_callback
         )
 
-        last_tool_index: IniValue = mo2_ini_data.get("Widgets", {}).get(
-            "MainWindow_executablesListBox_index", None
+        widgets: dict[str, IniValue] = (
+            _get_case_insensitive(mo2_ini_data, "Widgets") or {}
+        )
+        last_tool_index: IniValue = _get_case_insensitive(
+            widgets, "MainWindow_executablesListBox_index"
         )
         last_tool: Optional[Tool] = None
         if isinstance(last_tool_index, int):
@@ -318,7 +354,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             f"{instance_name} > {profile_name} in {duration:.2f}s."
         )
         if missing_metadata_count:
-            self.log.warning(f"{missing_metadata_count} loaded mod(s) have no metadata.")
+            self.log.warning(
+                f"{missing_metadata_count} loaded mod(s) have no metadata."
+            )
 
         return mods
 
@@ -548,23 +586,37 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
-        custom_executables: dict[str, IniValue] = mo2_ini_data.get(
-            "customExecutables", {}
+        custom_executables: dict[str, IniValue] = (
+            _get_case_insensitive(mo2_ini_data, "customExecutables") or {}
         )
-        custom_executables_size: IniValue = custom_executables.get("size", 0)
+        custom_executables_size: IniValue = (
+            _get_case_insensitive(custom_executables, "size") or 0
+        )
         if not isinstance(custom_executables_size, int):
             return []
 
         tools: list[Tool] = []
         for i in range(1, custom_executables_size + 1):
             try:
-                exe_path = Path(checked_cast(str, custom_executables[f"{i}\\binary"]))
-                raw_args: str = checked_cast(
-                    str, custom_executables[f"{i}\\arguments"] or ""
+                exe_path = Path(
+                    checked_cast(
+                        str,
+                        _get_case_insensitive(custom_executables, f"{i}\\binary"),
+                    )
                 )
-                name: str = checked_cast(str, custom_executables[f"{i}\\title"])
+                raw_args: str = checked_cast(
+                    str,
+                    _get_case_insensitive(custom_executables, f"{i}\\arguments") or "",
+                )
+                name: str = checked_cast(
+                    str,
+                    _get_case_insensitive(custom_executables, f"{i}\\title"),
+                )
                 raw_working_dir: Optional[IniValue] = custom_executables[
-                    f"{i}\\workingDirectory"
+                    _get_case_insensitive_key(
+                        custom_executables, f"{i}\\workingDirectory"
+                    )
+                    or f"{i}\\workingDirectory"
                 ]
             except Exception as ex:
                 self.log.error(f"Failed to load tool with index {i}: {ex}", exc_info=ex)
@@ -687,7 +739,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         instance_data.mods_folder.mkdir(parents=True, exist_ok=True)
         instance_data.profiles_folder.mkdir(parents=True, exist_ok=True)
-        os.makedirs(instance_data.profiles_folder / instance_data.profile, exist_ok=True)
+        os.makedirs(
+            instance_data.profiles_folder / instance_data.profile, exist_ok=True
+        )
         os.makedirs(instance_data.base_folder / "downloads", exist_ok=True)
         os.makedirs(instance_data.base_folder / "overwrite", exist_ok=True)
         (instance_data.profiles_folder / instance_data.profile / "modlist.txt").touch()
@@ -853,7 +907,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             instance.mods.append(new_mod)
 
     @staticmethod
-    def write_meta_ini_file(meta_ini_path: Path, metadata: Metadata, game: Game) -> None:
+    def write_meta_ini_file(
+        meta_ini_path: Path, metadata: Metadata, game: Game
+    ) -> None:
         """
         Writes metadata to a meta.ini file.
 
@@ -898,10 +954,16 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         mo2_ini_path: Path = instance_data.base_folder / "ModOrganizer.ini"
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
-        custom_executables: dict[str, IniValue] = mo2_ini_data.setdefault(
-            "customExecutables", {"size": 0}
+        section_key: Optional[str] = _get_case_insensitive_key(
+            mo2_ini_data, "customExecutables"
         )
-        new_index = int(custom_executables["size"]) + 1  # pyright: ignore[reportArgumentType]
+        if section_key is None:
+            section_key = "customExecutables"
+            mo2_ini_data[section_key] = {"size": 0}
+        custom_executables: dict[str, IniValue] = mo2_ini_data[section_key]
+
+        size_key: str = _get_case_insensitive_key(custom_executables, "size") or "size"
+        new_index = int(custom_executables.get(size_key) or 0) + 1
 
         new_tool: Tool = copy(tool)
         if new_tool.mod is not None and instance.is_mod_installed(new_tool.mod):
@@ -911,7 +973,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         custom_executables.update(
             ModOrganizer.tool_to_ini_data(new_tool, new_index, instance.game_folder)
         )
-        custom_executables["size"] = new_index
+        custom_executables[size_key] = new_index
 
         IniFile.save(mo2_ini_path, mo2_ini_data)
 
@@ -1007,12 +1069,24 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: dict[str, IniValue] = ini_data["Settings"]
-        base_dir = Path(settings.get("base_directory", mo2_ini_path.parent))  # pyright: ignore[reportArgumentType]
+        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "Settings"
+        )
+        if settings is None:
+            raise KeyError("Settings")
+        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        base_dir: Path = (
+            Path(checked_cast(str, raw_base_dir))
+            if raw_base_dir is not None
+            else mo2_ini_path.parent
+        )
 
         mods_dir: Path
-        if "mod_directory" in settings:
-            mods_dir = resolve(Path(settings["mod_directory"]), base_dir=str(base_dir))  # pyright: ignore[reportArgumentType]
+        raw_mods_dir: IniValue = _get_case_insensitive(settings, "mod_directory")
+        if raw_mods_dir is not None:
+            mods_dir = resolve(
+                Path(checked_cast(str, raw_mods_dir)), base_dir=str(base_dir)
+            )
         else:
             mods_dir = base_dir / "mods"
 
@@ -1031,13 +1105,25 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: dict[str, IniValue] = ini_data["Settings"]
-        base_dir = Path(settings.get("base_directory", mo2_ini_path.parent))  # pyright: ignore[reportArgumentType]
+        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "Settings"
+        )
+        if settings is None:
+            raise KeyError("Settings")
+        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        base_dir: Path = (
+            Path(checked_cast(str, raw_base_dir))
+            if raw_base_dir is not None
+            else mo2_ini_path.parent
+        )
 
         prof_dir: Path
-        if "profiles_directory" in settings:
+        raw_profiles_dir: IniValue = _get_case_insensitive(
+            settings, "profiles_directory"
+        )
+        if raw_profiles_dir is not None:
             prof_dir = resolve(
-                Path(settings["profiles_directory"]),  # pyright: ignore[reportArgumentType]
+                Path(checked_cast(str, raw_profiles_dir)),
                 base_dir=str(base_dir),
             )
         else:
@@ -1058,13 +1144,25 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: dict[str, IniValue] = ini_data["Settings"]
-        base_dir = Path(settings.get("base_directory", mo2_ini_path.parent))  # pyright: ignore[reportArgumentType]
+        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "Settings"
+        )
+        if settings is None:
+            raise KeyError("Settings")
+        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        base_dir: Path = (
+            Path(checked_cast(str, raw_base_dir))
+            if raw_base_dir is not None
+            else mo2_ini_path.parent
+        )
 
         overwrite_dir: Path
-        if "overwrite_directory" in settings:
+        raw_overwrite_dir: IniValue = _get_case_insensitive(
+            settings, "overwrite_directory"
+        )
+        if raw_overwrite_dir is not None:
             overwrite_dir = resolve(
-                Path(settings["overwrite_directory"]),  # pyright: ignore[reportArgumentType]
+                Path(checked_cast(str, raw_overwrite_dir)),
                 base_dir=str(base_dir),
             )
         else:
@@ -1085,13 +1183,25 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: dict[str, IniValue] = ini_data["Settings"]
-        base_dir = Path(settings.get("base_directory", mo2_ini_path.parent))  # pyright: ignore[reportArgumentType]
+        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "Settings"
+        )
+        if settings is None:
+            raise KeyError("Settings")
+        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        base_dir: Path = (
+            Path(checked_cast(str, raw_base_dir))
+            if raw_base_dir is not None
+            else mo2_ini_path.parent
+        )
 
         prof_dir: Path
-        if "profiles_directory" in settings:
+        raw_profiles_dir: IniValue = _get_case_insensitive(
+            settings, "profiles_directory"
+        )
+        if raw_profiles_dir is not None:
             prof_dir = resolve(
-                Path(settings["profiles_directory"]),  # pyright: ignore[reportArgumentType]
+                Path(checked_cast(str, raw_profiles_dir)),
                 base_dir=str(base_dir),
             )
         else:
@@ -1112,11 +1222,18 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        general: dict[str, IniValue] = ini_data["General"]
-        if "selected_profile" not in general:
+        general: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "General"
+        )
+        if general is None:
+            raise KeyError("General")
+
+        profile_name: Optional[IniValue] = _get_case_insensitive(
+            general, "selected_profile"
+        )
+        if profile_name is None:
             return
 
-        profile_name: Optional[IniValue] = general["selected_profile"]
         if not isinstance(profile_name, str):
             return
 

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -44,30 +44,32 @@ from .instance_info import MO2InstanceInfo
 MappingValueType = TypeVar("MappingValueType")
 
 
-def _get_case_insensitive(
-    mapping: Mapping[str, MappingValueType], key: str
-) -> Optional[MappingValueType]:
-    """Returns a mapping value without requiring an exact key case match."""
-
-    folded_key: str = key.casefold()
-    return next(
-        (value for name, value in mapping.items() if name.casefold() == folded_key),
-        None,
-    )
-
-
-def _get_case_insensitive_key(mapping: Mapping[str, object], key: str) -> Optional[str]:
-    """Returns the existing spelling of a mapping key, if present."""
-
-    folded_key: str = key.casefold()
-    return next((name for name in mapping if name.casefold() == folded_key), None)
-
-
 @final
 class ModOrganizer(ModManager[MO2InstanceInfo]):
     """
     API class for Mod Organizer 2.
     """
+
+    @staticmethod
+    def __get_case_insensitive(
+        mapping: Mapping[str, MappingValueType], key: str
+    ) -> Optional[MappingValueType]:
+        """Returns a mapping value without requiring an exact key case match."""
+
+        folded_key: str = key.casefold()
+        return next(
+            (value for name, value in mapping.items() if name.casefold() == folded_key),
+            None,
+        )
+
+    @staticmethod
+    def __get_case_insensitive_key(
+        mapping: Mapping[str, object], key: str
+    ) -> Optional[str]:
+        """Returns the existing spelling of a mapping key, if present."""
+
+        folded_key: str = key.casefold()
+        return next((name for name in mapping if name.casefold() == folded_key), None)
 
     # TODO: Make this dynamic instead of a fixed url
     DOWNLOAD_URL: str = "https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.2/Mod.Organizer-2.5.2.7z"
@@ -101,14 +103,14 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         if self.appdata_path.is_dir():
             for instance_ini in self.appdata_path.glob("**/ModOrganizer.ini"):
                 instance_data: IniData = IniFile.load(instance_ini)
-                general: Optional[dict[str, IniValue]] = _get_case_insensitive(
-                    instance_data, "General"
+                general: Optional[dict[str, IniValue]] = (
+                    ModOrganizer.__get_case_insensitive(instance_data, "General")
                 )
                 if general is None:
                     continue
 
                 instance_game: str = str(
-                    _get_case_insensitive(general, "gameName") or ""
+                    ModOrganizer.__get_case_insensitive(general, "gameName") or ""
                 )
                 if instance_game.lower() == game.display_name.lower():
                     instances.append(instance_ini.parent.name)
@@ -144,9 +146,11 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
         general: dict[str, IniValue] = (
-            _get_case_insensitive(mo2_ini_data, "General") or {}
+            ModOrganizer.__get_case_insensitive(mo2_ini_data, "General") or {}
         )
-        raw_game_folder: IniValue = _get_case_insensitive(general, "gamePath")
+        raw_game_folder: IniValue = ModOrganizer.__get_case_insensitive(
+            general, "gamePath"
+        )
         if isinstance(raw_game_folder, str):
             raw_game_folder = ModOrganizer.BYTE_ARRAY_PATTERN.sub(
                 r"\1", raw_game_folder
@@ -192,9 +196,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         )
 
         widgets: dict[str, IniValue] = (
-            _get_case_insensitive(mo2_ini_data, "Widgets") or {}
+            ModOrganizer.__get_case_insensitive(mo2_ini_data, "Widgets") or {}
         )
-        last_tool_index: IniValue = _get_case_insensitive(
+        last_tool_index: IniValue = ModOrganizer.__get_case_insensitive(
             widgets, "MainWindow_executablesListBox_index"
         )
         last_tool: Optional[Tool] = None
@@ -629,10 +633,10 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
         custom_executables: dict[str, IniValue] = (
-            _get_case_insensitive(mo2_ini_data, "customExecutables") or {}
+            ModOrganizer.__get_case_insensitive(mo2_ini_data, "customExecutables") or {}
         )
         custom_executables_size: IniValue = (
-            _get_case_insensitive(custom_executables, "size") or 0
+            ModOrganizer.__get_case_insensitive(custom_executables, "size") or 0
         )
         if not isinstance(custom_executables_size, int):
             return []
@@ -643,19 +647,26 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
                 exe_path = Path(
                     checked_cast(
                         str,
-                        _get_case_insensitive(custom_executables, f"{i}\\binary"),
+                        ModOrganizer.__get_case_insensitive(
+                            custom_executables, f"{i}\\binary"
+                        ),
                     )
                 )
                 raw_args: str = checked_cast(
                     str,
-                    _get_case_insensitive(custom_executables, f"{i}\\arguments") or "",
+                    ModOrganizer.__get_case_insensitive(
+                        custom_executables, f"{i}\\arguments"
+                    )
+                    or "",
                 )
                 name: str = checked_cast(
                     str,
-                    _get_case_insensitive(custom_executables, f"{i}\\title"),
+                    ModOrganizer.__get_case_insensitive(
+                        custom_executables, f"{i}\\title"
+                    ),
                 )
                 raw_working_dir: Optional[IniValue] = custom_executables[
-                    _get_case_insensitive_key(
+                    ModOrganizer.__get_case_insensitive_key(
                         custom_executables, f"{i}\\workingDirectory"
                     )
                     or f"{i}\\workingDirectory"
@@ -1053,7 +1064,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
 
         mo2_ini_path: Path = instance_data.base_folder / "ModOrganizer.ini"
         mo2_ini_data: IniData = IniFile.load(mo2_ini_path)
-        section_key: Optional[str] = _get_case_insensitive_key(
+        section_key: Optional[str] = ModOrganizer.__get_case_insensitive_key(
             mo2_ini_data, "customExecutables"
         )
         if section_key is None:
@@ -1061,7 +1072,10 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             mo2_ini_data[section_key] = {"size": 0}
         custom_executables: dict[str, IniValue] = mo2_ini_data[section_key]
 
-        size_key: str = _get_case_insensitive_key(custom_executables, "size") or "size"
+        size_key: str = (
+            ModOrganizer.__get_case_insensitive_key(custom_executables, "size")
+            or "size"
+        )
         new_index = int(custom_executables.get(size_key) or 0) + 1
 
         new_tool: Tool = copy(tool)
@@ -1162,20 +1176,22 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """Resolves a configured MO2 directory relative to its base directory."""
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+        settings: Optional[dict[str, IniValue]] = ModOrganizer.__get_case_insensitive(
             ini_data, "Settings"
         )
         if settings is None:
             raise KeyError("Settings")
 
-        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        raw_base_dir: IniValue = ModOrganizer.__get_case_insensitive(
+            settings, "base_directory"
+        )
         base_dir: Path = (
             Path(checked_cast(str, raw_base_dir))
             if raw_base_dir is not None
             else mo2_ini_path.parent
         )
 
-        raw_dir: IniValue = _get_case_insensitive(settings, directory_key)
+        raw_dir: IniValue = ModOrganizer.__get_case_insensitive(settings, directory_key)
         if raw_dir is None:
             return base_dir / default_name
 
@@ -1258,13 +1274,13 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         """
 
         ini_data: IniData = IniFile.load(mo2_ini_path)
-        general: Optional[dict[str, IniValue]] = _get_case_insensitive(
+        general: Optional[dict[str, IniValue]] = ModOrganizer.__get_case_insensitive(
             ini_data, "General"
         )
         if general is None:
             raise KeyError("General")
 
-        profile_name: Optional[IniValue] = _get_case_insensitive(
+        profile_name: Optional[IniValue] = ModOrganizer.__get_case_insensitive(
             general, "selected_profile"
         )
         if profile_name is None:

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -50,27 +50,6 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
     API class for Mod Organizer 2.
     """
 
-    @staticmethod
-    def __get_case_insensitive(
-        mapping: Mapping[str, MappingValueType], key: str
-    ) -> Optional[MappingValueType]:
-        """Returns a mapping value without requiring an exact key case match."""
-
-        folded_key: str = key.casefold()
-        return next(
-            (value for name, value in mapping.items() if name.casefold() == folded_key),
-            None,
-        )
-
-    @staticmethod
-    def __get_case_insensitive_key(
-        mapping: Mapping[str, object], key: str
-    ) -> Optional[str]:
-        """Returns the existing spelling of a mapping key, if present."""
-
-        folded_key: str = key.casefold()
-        return next((name for name in mapping if name.casefold() == folded_key), None)
-
     # TODO: Make this dynamic instead of a fixed url
     DOWNLOAD_URL: str = "https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.2/Mod.Organizer-2.5.2.7z"
 
@@ -1335,3 +1314,42 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             return profile_path.is_dir()
 
         return False
+
+    @staticmethod
+    def __get_case_insensitive(
+        mapping: Mapping[str, MappingValueType], key: str
+    ) -> Optional[MappingValueType]:
+        """
+        Gets a mapping value without requiring an exact key case match.
+
+        Args:
+            mapping (Mapping[str, MappingValueType]): Mapping to search.
+            key (str): Key to search for.
+
+        Returns:
+            Optional[MappingValueType]: Matching value, if present.
+        """
+
+        folded_key: str = key.casefold()
+        return next(
+            (value for name, value in mapping.items() if name.casefold() == folded_key),
+            None,
+        )
+
+    @staticmethod
+    def __get_case_insensitive_key(
+        mapping: Mapping[str, object], key: str
+    ) -> Optional[str]:
+        """
+        Gets the existing spelling of a mapping key, if present.
+
+        Args:
+            mapping (Mapping[str, object]): Mapping to search.
+            key (str): Key to search for.
+
+        Returns:
+            Optional[str]: Existing spelling of the matching key, if present.
+        """
+
+        folded_key: str = key.casefold()
+        return next((name for name in mapping if name.casefold() == folded_key), None)

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -987,7 +987,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         file_prefix: tuple[str, ...] = file.parts[: len(mods_folder_parts)]
         if tuple(part.casefold() for part in file_prefix) == tuple(
             part.casefold() for part in mods_folder_parts
-        ):
+        ) and len(file.parts) > len(mods_folder_parts):
             return Path(*file.parts[len(mods_folder_parts) :])
 
         return Path("Root") / file
@@ -1154,6 +1154,32 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         self.log.debug(f"Dumped settings to '{settings_ini_path}'.")
 
     @staticmethod
+    def __get_settings_folder(
+        mo2_ini_path: Path, directory_key: str, default_name: str
+    ) -> Path:
+        """Resolves a configured MO2 directory relative to its base directory."""
+
+        ini_data: IniData = IniFile.load(mo2_ini_path)
+        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
+            ini_data, "Settings"
+        )
+        if settings is None:
+            raise KeyError("Settings")
+
+        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
+        base_dir: Path = (
+            Path(checked_cast(str, raw_base_dir))
+            if raw_base_dir is not None
+            else mo2_ini_path.parent
+        )
+
+        raw_dir: IniValue = _get_case_insensitive(settings, directory_key)
+        if raw_dir is None:
+            return base_dir / default_name
+
+        return resolve(Path(checked_cast(str, raw_dir)), base_dir=str(base_dir))
+
+    @staticmethod
     def get_mods_folder(mo2_ini_path: Path) -> Path:
         """
         Gets the path to the mods folder of the specified MO2 instance.
@@ -1165,29 +1191,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             Path: Path to the mods folder.
         """
 
-        ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
-            ini_data, "Settings"
-        )
-        if settings is None:
-            raise KeyError("Settings")
-        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
-        base_dir: Path = (
-            Path(checked_cast(str, raw_base_dir))
-            if raw_base_dir is not None
-            else mo2_ini_path.parent
-        )
-
-        mods_dir: Path
-        raw_mods_dir: IniValue = _get_case_insensitive(settings, "mod_directory")
-        if raw_mods_dir is not None:
-            mods_dir = resolve(
-                Path(checked_cast(str, raw_mods_dir)), base_dir=str(base_dir)
-            )
-        else:
-            mods_dir = base_dir / "mods"
-
-        return mods_dir
+        return ModOrganizer.__get_settings_folder(mo2_ini_path, "mod_directory", "mods")
 
     @staticmethod
     def get_profiles_folder(mo2_ini_path: Path) -> Path:
@@ -1201,32 +1205,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             Path: Path to the profiles folder.
         """
 
-        ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
-            ini_data, "Settings"
+        return ModOrganizer.__get_settings_folder(
+            mo2_ini_path, "profiles_directory", "profiles"
         )
-        if settings is None:
-            raise KeyError("Settings")
-        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
-        base_dir: Path = (
-            Path(checked_cast(str, raw_base_dir))
-            if raw_base_dir is not None
-            else mo2_ini_path.parent
-        )
-
-        prof_dir: Path
-        raw_profiles_dir: IniValue = _get_case_insensitive(
-            settings, "profiles_directory"
-        )
-        if raw_profiles_dir is not None:
-            prof_dir = resolve(
-                Path(checked_cast(str, raw_profiles_dir)),
-                base_dir=str(base_dir),
-            )
-        else:
-            prof_dir = base_dir / "profiles"
-
-        return prof_dir
 
     @staticmethod
     def get_overwrite_folder(mo2_ini_path: Path) -> Path:
@@ -1240,32 +1221,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             Path: Path to the overwrite folder.
         """
 
-        ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
-            ini_data, "Settings"
+        return ModOrganizer.__get_settings_folder(
+            mo2_ini_path, "overwrite_directory", "overwrite"
         )
-        if settings is None:
-            raise KeyError("Settings")
-        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
-        base_dir: Path = (
-            Path(checked_cast(str, raw_base_dir))
-            if raw_base_dir is not None
-            else mo2_ini_path.parent
-        )
-
-        overwrite_dir: Path
-        raw_overwrite_dir: IniValue = _get_case_insensitive(
-            settings, "overwrite_directory"
-        )
-        if raw_overwrite_dir is not None:
-            overwrite_dir = resolve(
-                Path(checked_cast(str, raw_overwrite_dir)),
-                base_dir=str(base_dir),
-            )
-        else:
-            overwrite_dir = base_dir / "overwrite"
-
-        return overwrite_dir
 
     @staticmethod
     def get_profile_names(mo2_ini_path: Path) -> list[str]:
@@ -1279,30 +1237,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             list[str]: List of profile names.
         """
 
-        ini_data: IniData = IniFile.load(mo2_ini_path)
-        settings: Optional[dict[str, IniValue]] = _get_case_insensitive(
-            ini_data, "Settings"
+        prof_dir: Path = ModOrganizer.__get_settings_folder(
+            mo2_ini_path, "profiles_directory", "profiles"
         )
-        if settings is None:
-            raise KeyError("Settings")
-        raw_base_dir: IniValue = _get_case_insensitive(settings, "base_directory")
-        base_dir: Path = (
-            Path(checked_cast(str, raw_base_dir))
-            if raw_base_dir is not None
-            else mo2_ini_path.parent
-        )
-
-        prof_dir: Path
-        raw_profiles_dir: IniValue = _get_case_insensitive(
-            settings, "profiles_directory"
-        )
-        if raw_profiles_dir is not None:
-            prof_dir = resolve(
-                Path(checked_cast(str, raw_profiles_dir)),
-                base_dir=str(base_dir),
-            )
-        else:
-            prof_dir = base_dir / "profiles"
 
         return sorted([prof.name for prof in prof_dir.iterdir() if prof.is_dir()])
 

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -925,7 +925,7 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
                     game.short_name, game.short_name
                 ),
                 "modid": metadata.mod_id,
-                "version": metadata.version,
+                "version": ModOrganizer.__format_version(metadata.version),
                 "installationFile": metadata.file_name,
             },
             "installedFiles": {
@@ -935,6 +935,17 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             },
         }
         IniFile.save(meta_ini_path, meta_ini_data)
+
+    @staticmethod
+    def __format_version(version: str) -> str:
+        """Pads a non-empty MO2 version to at least four segments."""
+
+        if not version:
+            return version
+
+        segments: list[str] = version.split(".")
+        segments.extend("0" for _ in range(4 - len(segments)))
+        return ".".join(segments)
 
     @override
     def add_tool(

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -321,6 +321,8 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             )
             mods.append(mod)
 
+        ModOrganizer.__assign_variants(mods)
+
         # Load overwrite folder as mod
         overwrite_folder: Path = ModOrganizer.get_overwrite_folder(mo2_ini_path)
         if overwrite_folder.is_dir() and os.listdir(overwrite_folder):
@@ -359,6 +361,46 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
             )
 
         return mods
+
+    @staticmethod
+    def __assign_variants(mods: list[Mod]) -> None:
+        """Assigns stable variants to mods sharing an installation archive."""
+
+        mods_by_archive: dict[str, list[Mod]] = {}
+        for mod in mods:
+            if mod.metadata.file_name:
+                mods_by_archive.setdefault(
+                    mod.metadata.file_name.casefold(), []
+                ).append(mod)
+
+        for matching_mods in mods_by_archive.values():
+            if len(matching_mods) < 2:
+                continue
+
+            base_mod: Mod = min(matching_mods, key=lambda mod: len(mod.display_name))
+            used_variants: set[str] = set()
+            for index, mod in enumerate(matching_mods, start=1):
+                if mod is base_mod:
+                    continue
+
+                if mod.display_name.casefold().startswith(
+                    base_mod.display_name.casefold()
+                ):
+                    variant: str = mod.display_name[len(base_mod.display_name) :].strip(
+                        "-_. "
+                    )
+                else:
+                    variant = mod.display_name.strip("-_. ")
+
+                variant = clean_fs_string(variant) or f"variant-{index}"
+                unique_variant: str = variant
+                suffix: int = 2
+                while unique_variant.casefold() in used_variants:
+                    unique_variant = f"{variant}-{suffix}"
+                    suffix += 1
+
+                mod.variant = unique_variant
+                used_variants.add(unique_variant.casefold())
 
     def parse_meta_ini(self, meta_ini_path: Path, default_game: Game) -> Metadata:
         """

--- a/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
+++ b/src/mod_manager_lib/core/mod_manager/modorganizer/api.py
@@ -987,7 +987,9 @@ class ModOrganizer(ModManager[MO2InstanceInfo]):
         file_prefix: tuple[str, ...] = file.parts[: len(mods_folder_parts)]
         if tuple(part.casefold() for part in file_prefix) == tuple(
             part.casefold() for part in mods_folder_parts
-        ) and len(file.parts) > len(mods_folder_parts):
+        ):
+            if len(file.parts) == len(mods_folder_parts):
+                return file
             return Path(*file.parts[len(mods_folder_parts) :])
 
         return Path("Root") / file

--- a/src/mod_manager_lib/core/mod_manager/vortex/api.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/api.py
@@ -613,6 +613,30 @@ class Vortex(ModManager[ProfileInfo]):
             .get(vortex_id, {})
         )
 
+        if not db_mod_data and mod.variant is None:
+            legacy_vortex_id: str = installation_file_name.rsplit(".", 1)[0]
+            if legacy_vortex_id != vortex_id:
+                legacy_db_prefix: str = (
+                    f"persistent###mods###{game_id}###{legacy_vortex_id}###"
+                )
+                db_mod_data = (
+                    self.__level_db.get_section(legacy_db_prefix)
+                    .get("persistent", {})
+                    .get("mods", {})
+                    .get(game_id, {})
+                    .get(legacy_vortex_id, {})
+                )
+                if db_mod_data:
+                    self.__level_db.delete_section(legacy_db_prefix)
+                    db_mod_data["id"] = vortex_id
+                    mod_folder = staging_folder / db_mod_data.get(
+                        "installationPath", vortex_id
+                    )
+                    self.log.info(
+                        f"Migrating legacy Vortex ID '{legacy_vortex_id}' to "
+                        f"'{vortex_id}'."
+                    )
+
         if not db_mod_data:
             logical_file_name: str = Vortex.get_logical_file_name(
                 installation_file_name, mod.metadata.mod_id or 0

--- a/src/mod_manager_lib/core/mod_manager/vortex/api.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/api.py
@@ -205,6 +205,7 @@ class Vortex(ModManager[ProfileInfo]):
         staging_folder: Path = self.__get_staging_folder(game)
 
         mods: list[Mod] = []
+        mods_by_id: dict[str, Mod] = {}
         conflict_rules: dict[Mod, list[dict]] = {}
         file_overrides: dict[Mod, list[str]] = {}
         for m, modname in enumerate(modnames):
@@ -234,9 +235,14 @@ class Vortex(ModManager[ProfileInfo]):
                 or mod_meta_data.get("logicalFileName")
                 or mod_meta_data.get("modName")
                 or modname
-            )[:modname_limit].strip("-_. ")  # Limit mod name as it can get very long
+            )
             mod_path: Path = staging_folder / moddata.get("installationPath", modname)
             file_name: str = mod_meta_data.get("fileName", mod_path.name)
+            variant: Optional[str] = Vortex.__get_variant(modname, file_name)
+            if variant and not display_name.casefold().endswith(variant.casefold()):
+                display_name += f" - {variant}"
+            # Limit mod name as it can get very long.
+            display_name = display_name[:modname_limit].strip("-_. ")
 
             deploy_path: Optional[Path] = None
             modtype: Optional[str] = moddata.get("type") or None
@@ -298,10 +304,12 @@ class Vortex(ModManager[ProfileInfo]):
                     file_name=file_name,
                     game_id=dl_game_id,
                 ),
+                variant=variant,
                 installed=True,
                 enabled=mod_state_data.get(modname, {}).get("enabled", False),
             )
             mods.append(mod)
+            mods_by_id[modname] = mod
             rules: list[dict] = moddata.get("rules", [])
             if rules:
                 conflict_rules[mod] = rules
@@ -310,7 +318,7 @@ class Vortex(ModManager[ProfileInfo]):
                 file_overrides[mod] = overrides
 
         if load_conflicts:
-            self.__process_conflict_rules(mods, conflict_rules)
+            self.__process_conflict_rules(mods_by_id, conflict_rules)
 
             mod_overrides: dict[Mod, list[Mod]] = self.get_reversed_mod_conflicts(mods)
             self.__process_file_overrides(
@@ -322,15 +330,12 @@ class Vortex(ModManager[ProfileInfo]):
         return mods
 
     def __process_conflict_rules(
-        self, mods: list[Mod], conflict_rules: dict[Mod, list[dict]]
+        self, mods_by_id: dict[str, Mod], conflict_rules: dict[Mod, list[dict]]
     ) -> None:
         self.log.info(f"Processing conflict rules for {len(conflict_rules)} mod(s)...")
-        mods_by_file_name: dict[str, Mod] = {
-            self.__get_unique_file_name(mod).rsplit(".", 1)[0]: mod for mod in mods
-        }
         mod_overwrites: dict[Mod, list[Mod]] = {}
 
-        for mod in mods:
+        for mod in mods_by_id.values():
             rules: list[dict[str, dict | str]] = conflict_rules.get(mod, [])
 
             for rule in rules:
@@ -346,7 +351,7 @@ class Vortex(ModManager[ProfileInfo]):
                     )
                     continue
 
-                ref_mod: Optional[Mod] = mods_by_file_name.get(ref_modname)
+                ref_mod: Optional[Mod] = mods_by_id.get(ref_modname)
 
                 # Ignore conflicts with mods that aren't relevant to us
                 if ref_mod is None:
@@ -584,20 +589,21 @@ class Vortex(ModManager[ProfileInfo]):
         game_id: str = instance_data.game.id.lower()
         staging_folder: Path = self.__get_staging_folder(instance_data.game)
 
-        file_name: str = self.__get_unique_file_name(mod).rsplit(".", 1)[0]
-        mod_folder: Path = staging_folder / file_name
-        db_prefix: str = f"persistent###mods###{game_id}###{file_name}###"
+        installation_file_name: str = self.__get_installation_file_name(mod)
+        vortex_id: str = self.__get_vortex_id(mod)
+        mod_folder: Path = staging_folder / vortex_id
+        db_prefix: str = f"persistent###mods###{game_id}###{vortex_id}###"
         db_mod_data: dict[str, Any] = (
             self.__level_db.get_section(db_prefix)
             .get("persistent", {})
             .get("mods", {})
             .get(game_id, {})
-            .get(file_name, {})
+            .get(vortex_id, {})
         )
 
         if not db_mod_data:
             logical_file_name: str = Vortex.get_logical_file_name(
-                self.__get_unique_file_name(mod), mod.metadata.mod_id or 0
+                installation_file_name, mod.metadata.mod_id or 0
             )
             source: str = "nexus" if mod.metadata.mod_id else "other"
             modtype: Optional[str] = "dinput" if mod.deploy_path else None
@@ -619,15 +625,15 @@ class Vortex(ModManager[ProfileInfo]):
                     "customFileName": mod.display_name,
                     "downloadGame": dl_game_id,
                     "installTime": Vortex.format_utc_timestamp(time.time()),
-                    "fileName": self.__get_unique_file_name(mod),
+                    "fileName": installation_file_name,
                     "fileId": mod.metadata.file_id,
                     "modId": mod.metadata.mod_id,
                     "logicalFileName": logical_file_name,
                     "version": mod.metadata.version,
                     "source": source,
                 },
-                "id": file_name,
-                "installationPath": file_name,
+                "id": vortex_id,
+                "installationPath": vortex_id,
                 "state": "installed",
                 "type": modtype,
             }
@@ -648,11 +654,9 @@ class Vortex(ModManager[ProfileInfo]):
         rules: list[dict[str, Any]] = db_mod_data.get("rules", [])
         # Check for rules
         for overwriting_mod in mod.mod_conflicts:
-            overwriting_mod_filename: str = self.__get_unique_file_name(
-                overwriting_mod
-            ).rsplit(".", 1)[0]
+            overwriting_mod_filename: str = self.__get_vortex_id(overwriting_mod)
 
-            if overwriting_mod_filename == file_name:
+            if overwriting_mod_filename == vortex_id:
                 raise ValueError(
                     f"Cyclic dependency detected in '{mod.display_name}': Mod conflicts with itself!"
                 )
@@ -683,7 +687,7 @@ class Vortex(ModManager[ProfileInfo]):
 
         # Add mod to profile
         profile_db_prefix: str = (
-            f"persistent###profiles###{instance_data.id}###modState###{file_name}###"
+            f"persistent###profiles###{instance_data.id}###modState###{vortex_id}###"
         )
         profile_mod_data: dict[str, Any] = (
             self.__level_db.get_section(profile_db_prefix)
@@ -691,7 +695,7 @@ class Vortex(ModManager[ProfileInfo]):
             .get("profiles", {})
             .get(instance_data.id, {})
             .get("modState", {})
-            .get(file_name, {})
+            .get(vortex_id, {})
         )
         profile_mod_data["enabled"] = mod.enabled
         profile_mod_data["enabledTime"] = Vortex.format_unix_timestamp(time.time())
@@ -844,13 +848,14 @@ class Vortex(ModManager[ProfileInfo]):
                 continue
 
             self.log.debug(f"Setting file overrides for '{mod.display_name}'...")
-            full_mod_name: str = self.__get_unique_file_name(mod).rsplit(".", 1)[0]
+            full_mod_name: str = self.__get_vortex_id(mod)
             prefix: str = f"persistent###mods###{game.id.lower()}###{full_mod_name}###"
-            mod_data: dict[str, Any] = self.__level_db.get_section(prefix)["persistent"][
-                "mods"
-            ][game.id.lower()][full_mod_name]
+            mod_data: dict[str, Any] = self.__level_db.get_section(prefix)[
+                "persistent"
+            ]["mods"][game.id.lower()][full_mod_name]
             mod_data["fileOverrides"] = [
-                str(game_folder / game.mods_folder / file) for file in mod.file_conflicts
+                str(game_folder / game.mods_folder / file)
+                for file in mod.file_conflicts
             ]
             self.__level_db.set_section(prefix, mod_data)
 
@@ -895,13 +900,29 @@ class Vortex(ModManager[ProfileInfo]):
     def get_mods_path(self, instance_data: ProfileInfo) -> Path:
         return self.__get_staging_folder(instance_data.game)
 
-    def __get_unique_file_name(self, mod: Mod) -> str:
+    def __get_installation_file_name(self, mod: Mod) -> str:
         return mod.metadata.file_name or Vortex.create_unique_file_name(
             mod_name=mod.display_name,
             mod_id=mod.metadata.mod_id,
             file_id=mod.metadata.file_id,
             version=mod.metadata.version,
         )
+
+    def __get_vortex_id(self, mod: Mod) -> str:
+        vortex_id: str = self.__get_installation_file_name(mod).rsplit(".", 1)[0]
+        if mod.variant:
+            vortex_id += f"-{mod.variant}"
+
+        return clean_fs_string(vortex_id)
+
+    @staticmethod
+    def __get_variant(vortex_id: str, installation_file_name: str) -> Optional[str]:
+        archive_id: str = installation_file_name.rsplit(".", 1)[0]
+        if not vortex_id.casefold().startswith(archive_id.casefold()):
+            return None
+
+        variant: str = vortex_id[len(archive_id) :].strip("-_. ")
+        return variant or None
 
     @staticmethod
     def get_logical_file_name(full_file_name: str, mod_id: int) -> str:

--- a/src/mod_manager_lib/core/mod_manager/vortex/api.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/api.py
@@ -354,16 +354,21 @@ class Vortex(ModManager[ProfileInfo]):
                     mods_by_id.get(ref_mod_id) if ref_mod_id is not None else None
                 )
                 if ref_mod is None and file_expression is not None:
-                    ref_mod = next(
-                        (
-                            candidate
-                            for candidate in mods_by_id.values()
-                            if candidate.metadata.file_name is not None
-                            and candidate.metadata.file_name.casefold()
-                            == file_expression.casefold()
-                        ),
-                        None,
-                    )
+                    ref_mod_candidates: list[Mod] = [
+                        candidate
+                        for candidate in mods_by_id.values()
+                        if candidate.metadata.file_name is not None
+                        and candidate.metadata.file_name.casefold()
+                        == file_expression.casefold()
+                    ]
+                    if len(ref_mod_candidates) == 1:
+                        ref_mod = ref_mod_candidates[0]
+                    elif len(ref_mod_candidates) > 1:
+                        self.log.warning(
+                            "Failed to process mod conflict rule for mod "
+                            f"'{mod.display_name}': Ambiguous fileExpression "
+                            f"'{file_expression}' matches multiple mods."
+                        )
 
                 # Ignore conflicts with mods that aren't relevant to us
                 if ref_mod is None:

--- a/src/mod_manager_lib/core/mod_manager/vortex/api.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/api.py
@@ -627,6 +627,32 @@ class Vortex(ModManager[ProfileInfo]):
                     .get(legacy_vortex_id, {})
                 )
                 if db_mod_data:
+                    profiles_data: dict[str, Any] = (
+                        self.__level_db.get_section("persistent###profiles###")
+                        .get("persistent", {})
+                        .get("profiles", {})
+                    )
+                    for profile_id, profile_data in profiles_data.items():
+                        mod_states: dict[str, dict[str, Any]] = profile_data.get(
+                            "modState", {}
+                        )
+                        if legacy_vortex_id not in mod_states:
+                            continue
+
+                        legacy_profile_prefix: str = (
+                            f"persistent###profiles###{profile_id}###modState###"
+                            f"{legacy_vortex_id}###"
+                        )
+                        self.__level_db.delete_section(legacy_profile_prefix)
+                        if vortex_id not in mod_states:
+                            profile_prefix: str = (
+                                f"persistent###profiles###{profile_id}###modState###"
+                                f"{vortex_id}###"
+                            )
+                            self.__level_db.set_section(
+                                profile_prefix, mod_states[legacy_vortex_id]
+                            )
+
                     self.__level_db.delete_section(legacy_db_prefix)
                     db_mod_data["id"] = vortex_id
                     mod_folder = staging_folder / db_mod_data.get(

--- a/src/mod_manager_lib/core/mod_manager/vortex/api.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/api.py
@@ -239,10 +239,10 @@ class Vortex(ModManager[ProfileInfo]):
             mod_path: Path = staging_folder / moddata.get("installationPath", modname)
             file_name: str = mod_meta_data.get("fileName", mod_path.name)
             variant: Optional[str] = Vortex.__get_variant(modname, file_name)
+            # Limit the base name while retaining the complete variant suffix.
+            display_name = display_name[:modname_limit].strip("-_. ")
             if variant and not display_name.casefold().endswith(variant.casefold()):
                 display_name += f" - {variant}"
-            # Limit mod name as it can get very long.
-            display_name = display_name[:modname_limit].strip("-_. ")
 
             deploy_path: Optional[Path] = None
             modtype: Optional[str] = moddata.get("type") or None
@@ -340,18 +340,30 @@ class Vortex(ModManager[ProfileInfo]):
 
             for rule in rules:
                 reference: dict[str, str] = rule["reference"]  # type: ignore[assignment]
-                ref_modname: Optional[str] = reference.get("id") or reference.get(
-                    "fileExpression"
-                )
+                ref_mod_id: Optional[str] = reference.get("id")
+                file_expression: Optional[str] = reference.get("fileExpression")
 
-                if ref_modname is None:
+                if ref_mod_id is None and file_expression is None:
                     self.log.warning(
                         "Failed to process mod conflict rule for mod "
                         f"'{mod.display_name}': Reference mod name is empty!"
                     )
                     continue
 
-                ref_mod: Optional[Mod] = mods_by_id.get(ref_modname)
+                ref_mod: Optional[Mod] = (
+                    mods_by_id.get(ref_mod_id) if ref_mod_id is not None else None
+                )
+                if ref_mod is None and file_expression is not None:
+                    ref_mod = next(
+                        (
+                            candidate
+                            for candidate in mods_by_id.values()
+                            if candidate.metadata.file_name is not None
+                            and candidate.metadata.file_name.casefold()
+                            == file_expression.casefold()
+                        ),
+                        None,
+                    )
 
                 # Ignore conflicts with mods that aren't relevant to us
                 if ref_mod is None:
@@ -917,7 +929,7 @@ class Vortex(ModManager[ProfileInfo]):
 
     @staticmethod
     def __get_variant(vortex_id: str, installation_file_name: str) -> Optional[str]:
-        archive_id: str = installation_file_name.rsplit(".", 1)[0]
+        archive_id: str = clean_fs_string(installation_file_name.rsplit(".", 1)[0])
         if not vortex_id.casefold().startswith(archive_id.casefold()):
             return None
 

--- a/src/mod_manager_lib/core/mod_manager/vortex/leveldb.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/leveldb.py
@@ -30,7 +30,7 @@ class LevelDB:
     __symlink_path: Optional[Path]
 
     __data: dict[str, str]
-    __deleted_keys: set[str]
+    __deleted_prefixes: set[str]
     __changes_pending: bool
 
     log: logging.Logger = logging.getLogger("LevelDB")
@@ -47,7 +47,7 @@ class LevelDB:
 
         self.__symlink_path = None
         self.__data = {}
-        self.__deleted_keys = set()
+        self.__deleted_prefixes = set()
         self.__changes_pending = False
 
     def get_symlink_path(self) -> Path:
@@ -141,7 +141,10 @@ class LevelDB:
         with ldb.DB(str(db_path)) as database:
             for key, value in database.iterator(prefix=prefix):
                 decoded_key: str = key.decode()
-                if decoded_key not in self.__deleted_keys:
+                if not any(
+                    decoded_key.startswith(deleted_prefix)
+                    for deleted_prefix in self.__deleted_prefixes
+                ):
                     raw_data[decoded_key] = value.decode()
 
         self.__data.update(raw_data)
@@ -162,12 +165,17 @@ class LevelDB:
         self.log.info(f"Saving database to '{db_path}'...")
 
         with ldb.DB(str(db_path)) as database, database.write_batch() as batch:
-            for key in self.__deleted_keys:
-                batch.delete(key.encode())
+            deleted_keys: set[bytes] = {
+                key
+                for prefix in self.__deleted_prefixes
+                for key, _ in database.iterator(prefix=prefix.encode())
+            }
+            for key in deleted_keys:
+                batch.delete(key)
             for key, value in self.__data.items():
                 batch.put(key.encode(), value.encode())
 
-        self.__deleted_keys.clear()
+        self.__deleted_prefixes.clear()
         self.__changes_pending = False
         self.log.info("Database saved.")
 
@@ -191,7 +199,10 @@ class LevelDB:
         with ldb.DB(str(db_path)) as database:
             for raw_key, raw_value in database.iterator(prefix=prefix_bytes):
                 key: str = raw_key.decode()
-                if key not in self.__data and key not in self.__deleted_keys:
+                if key not in self.__data and not any(
+                    key.startswith(deleted_prefix)
+                    for deleted_prefix in self.__deleted_prefixes
+                ):
                     self.__data[key] = raw_value.decode()
                     self.__changes_pending = True
 
@@ -214,7 +225,6 @@ class LevelDB:
 
         raw_data: dict[str, str] = LevelDB.flatten_nested_dict(data, prefix=prefix)
         self.__data.update(raw_data)
-        self.__deleted_keys.difference_update(raw_data)
         self.__changes_pending = True
 
     def delete_section(self, prefix: str) -> None:
@@ -225,19 +235,9 @@ class LevelDB:
             prefix (str): The prefix of the section to delete.
         """
 
-        keys: set[str] = {key for key in self.__data if key.startswith(prefix)}
-        with ldb.DB(str(self.get_symlink_path())) as database:
-            keys.update(
-                raw_key.decode()
-                for raw_key, _ in database.iterator(prefix=prefix.encode())
-            )
-
-        if not keys:
-            return
-
-        for key in keys:
+        for key in [key for key in self.__data if key.startswith(prefix)]:
             self.__data.pop(key, None)
-        self.__deleted_keys.update(keys)
+        self.__deleted_prefixes.add(prefix)
         self.__changes_pending = True
 
     def get_key(self, key: str) -> Optional[Any]:
@@ -252,7 +252,10 @@ class LevelDB:
             Optional[Any]: The value of the key or None if the key does not exist.
         """
 
-        if key in self.__deleted_keys:
+        if key in self.__data:
+            return json.loads(self.__data.get(key))
+
+        if any(key.startswith(prefix) for prefix in self.__deleted_prefixes):
             return None
 
         if key not in self.__data:
@@ -271,7 +274,6 @@ class LevelDB:
         """
 
         self.__data[key] = json.dumps(value)
-        self.__deleted_keys.discard(key)
         self.__changes_pending = True
 
     @staticmethod

--- a/src/mod_manager_lib/core/mod_manager/vortex/leveldb.py
+++ b/src/mod_manager_lib/core/mod_manager/vortex/leveldb.py
@@ -30,6 +30,7 @@ class LevelDB:
     __symlink_path: Optional[Path]
 
     __data: dict[str, str]
+    __deleted_keys: set[str]
     __changes_pending: bool
 
     log: logging.Logger = logging.getLogger("LevelDB")
@@ -46,6 +47,7 @@ class LevelDB:
 
         self.__symlink_path = None
         self.__data = {}
+        self.__deleted_keys = set()
         self.__changes_pending = False
 
     def get_symlink_path(self) -> Path:
@@ -138,7 +140,9 @@ class LevelDB:
 
         with ldb.DB(str(db_path)) as database:
             for key, value in database.iterator(prefix=prefix):
-                raw_data[key.decode()] = value.decode()
+                decoded_key: str = key.decode()
+                if decoded_key not in self.__deleted_keys:
+                    raw_data[decoded_key] = value.decode()
 
         self.__data.update(raw_data)
         self.log.info("Database loaded.")
@@ -158,9 +162,12 @@ class LevelDB:
         self.log.info(f"Saving database to '{db_path}'...")
 
         with ldb.DB(str(db_path)) as database, database.write_batch() as batch:
+            for key in self.__deleted_keys:
+                batch.delete(key.encode())
             for key, value in self.__data.items():
                 batch.put(key.encode(), value.encode())
 
+        self.__deleted_keys.clear()
         self.__changes_pending = False
         self.log.info("Database saved.")
 
@@ -184,7 +191,7 @@ class LevelDB:
         with ldb.DB(str(db_path)) as database:
             for raw_key, raw_value in database.iterator(prefix=prefix_bytes):
                 key: str = raw_key.decode()
-                if key not in self.__data:
+                if key not in self.__data and key not in self.__deleted_keys:
                     self.__data[key] = raw_value.decode()
                     self.__changes_pending = True
 
@@ -207,6 +214,30 @@ class LevelDB:
 
         raw_data: dict[str, str] = LevelDB.flatten_nested_dict(data, prefix=prefix)
         self.__data.update(raw_data)
+        self.__deleted_keys.difference_update(raw_data)
+        self.__changes_pending = True
+
+    def delete_section(self, prefix: str) -> None:
+        """
+        Deletes all key-value pairs starting with the given prefix on save.
+
+        Args:
+            prefix (str): The prefix of the section to delete.
+        """
+
+        keys: set[str] = {key for key in self.__data if key.startswith(prefix)}
+        with ldb.DB(str(self.get_symlink_path())) as database:
+            keys.update(
+                raw_key.decode()
+                for raw_key, _ in database.iterator(prefix=prefix.encode())
+            )
+
+        if not keys:
+            return
+
+        for key in keys:
+            self.__data.pop(key, None)
+        self.__deleted_keys.update(keys)
         self.__changes_pending = True
 
     def get_key(self, key: str) -> Optional[Any]:
@@ -220,6 +251,9 @@ class LevelDB:
         Returns:
             Optional[Any]: The value of the key or None if the key does not exist.
         """
+
+        if key in self.__deleted_keys:
+            return None
 
         if key not in self.__data:
             self.load(prefix=key)
@@ -237,6 +271,7 @@ class LevelDB:
         """
 
         self.__data[key] = json.dumps(value)
+        self.__deleted_keys.discard(key)
         self.__changes_pending = True
 
     @staticmethod

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -418,6 +418,62 @@ class TestModOrganizer(BaseTest):
         meta_ini_data: IniData = IniFile.load(meta_ini_path)
         assert meta_ini_data["General"]["version"] == expected_version
 
+    def test_load_mods_assigns_variants_for_shared_archive(
+        self, test_fs: FakeFilesystem, mo2_instance_info: MO2InstanceInfo
+    ) -> None:
+        """
+        Tests that MO2 mods from the same archive receive distinct variants.
+        """
+
+        # given
+        mo2 = ModOrganizer()
+        archive_name = "Dear Diary Dark Mode-60837-1-1-1-1667594519.7z"
+        mod_names: list[str] = [
+            "Dear Diary Dark Mode",
+            "Dear Diary Dark Mode - 21x9",
+        ]
+        metadata = Metadata(
+            mod_id=60837,
+            file_id=1,
+            version="1.1.1",
+            file_name=archive_name,
+            game_id="skyrimspecialedition",
+        )
+        for mod_name in mod_names:
+            mod_folder: Path = mo2_instance_info.mods_folder / mod_name
+            mod_folder.mkdir()
+            ModOrganizer.write_meta_ini_file(
+                mod_folder / "meta.ini", metadata, mo2_instance_info.game
+            )
+            test_fs.create_file(mod_folder / "interface" / f"{mod_name}.txt")
+
+        modlist_path: Path = (
+            mo2_instance_info.profiles_folder
+            / mo2_instance_info.profile
+            / "modlist.txt"
+        )
+        modlist_path.write_text(
+            modlist_path.read_text()
+            + "\n"
+            + "\n".join(f"+{name}" for name in mod_names)
+        )
+
+        # when
+        mods: list[Mod] = mo2.load_mods(
+            mo2_instance_info,
+            Path("E:/SteamLibrary/Skyrim Special Edition"),
+            load_conflicts=False,
+        )
+
+        # then
+        base_mod: Mod = next(mod for mod in mods if mod.display_name == mod_names[0])
+        variant_mod: Mod = next(mod for mod in mods if mod.display_name == mod_names[1])
+        assert base_mod.metadata.file_name == archive_name
+        assert variant_mod.metadata.file_name == archive_name
+        assert base_mod.variant is None
+        assert variant_mod.variant == "21x9"
+        assert Mod.create_copy(variant_mod).variant == "21x9"
+
     def test_install_mod_with_separator(
         self, test_fs: FakeFilesystem, instance: Instance
     ) -> None:

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -181,6 +181,14 @@ class TestModOrganizer(BaseTest):
         assert instance.game_folder == Path("E:/SteamLibrary/Skyrim Special Edition")
         assert len(instance.tools) == 4
         assert mo2.get_instance_names(mo2_instance_info.game) == ["Test Instance"]
+        assert mo2.get_mods_folder(portable_ini_path) == mo2_instance_info.mods_folder
+        assert (
+            mo2.get_profiles_folder(portable_ini_path)
+            == mo2_instance_info.profiles_folder
+        )
+        assert mo2.get_overwrite_folder(portable_ini_path) == (
+            mo2_instance_info.base_folder / "overwrite"
+        )
         assert mo2.get_profile_names(portable_ini_path) == ["Default", "TestProfile"]
         assert mo2.get_last_active_profile(portable_ini_path) == "Default"
 
@@ -202,6 +210,12 @@ class TestModOrganizer(BaseTest):
         """
         Method stub for `ModOrganizer.__process_conflicts()`.
         """
+
+        raise NotImplementedError
+
+    @staticmethod
+    def get_root_builder_path_stub(file: Path, mods_folder: Path) -> Path:
+        """Stub for `ModOrganizer.__get_root_builder_path`."""
 
         raise NotImplementedError
 
@@ -445,6 +459,24 @@ class TestModOrganizer(BaseTest):
         assert (mod_folder / "Scripts" / "hidden.pex.mohidden").is_file()
         assert not (mod_folder / "Data").exists()
         assert not (mod_folder / "Root" / "Data").exists()
+
+    def test_root_builder_treats_file_named_like_mods_folder_as_root_file(
+        self,
+    ) -> None:
+        """Tests a file named `Data` is not redirected to the mod directory itself."""
+
+        # given
+        get_root_builder_path = Utils.get_private_method(
+            ModOrganizer,
+            "get_root_builder_path",
+            self.get_root_builder_path_stub,
+        )
+
+        # when
+        root_builder_path: Path = get_root_builder_path(Path("Data"), Path("data"))
+
+        # then
+        assert root_builder_path == Path("Root/Data")
 
     @pytest.mark.parametrize(
         ("version", "expected_version"),

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -460,10 +460,10 @@ class TestModOrganizer(BaseTest):
         assert not (mod_folder / "Data").exists()
         assert not (mod_folder / "Root" / "Data").exists()
 
-    def test_root_builder_treats_file_named_like_mods_folder_as_root_file(
+    def test_root_builder_keeps_file_named_like_mods_folder_at_mod_root(
         self,
     ) -> None:
-        """Tests a file named `Data` is not redirected to the mod directory itself."""
+        """Tests a file named `Data` remains a file at the MO2 mod root."""
 
         # given
         get_root_builder_path = Utils.get_private_method(
@@ -476,7 +476,7 @@ class TestModOrganizer(BaseTest):
         root_builder_path: Path = get_root_builder_path(Path("Data"), Path("data"))
 
         # then
-        assert root_builder_path == Path("Root/Data")
+        assert root_builder_path == Path("Data")
 
     @pytest.mark.parametrize(
         ("version", "expected_version"),

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -380,6 +380,44 @@ class TestModOrganizer(BaseTest):
         assert migrated_overwritten_mod.files == overwritten_mod.files
         assert migrated_overwriting_mod.files == overwriting_mod.files
 
+    @pytest.mark.parametrize(
+        ("version", "expected_version"),
+        [
+            ("", None),
+            ("1", "1.0.0.0"),
+            ("1.0", "1.0.0.0"),
+            ("1.2.3", "1.2.3.0"),
+            ("1.2.3.4", "1.2.3.4"),
+            ("1.2.3.4.5", "1.2.3.4.5"),
+            ("f1.07", "f1.07.0.0"),
+        ],
+    )
+    def test_write_meta_ini_file_pads_version(
+        self, tmp_path: Path, version: str, expected_version: IniValue
+    ) -> None:
+        """
+        Tests that generated MO2 metadata contains at least four version segments.
+        """
+
+        # given
+        meta_ini_path: Path = tmp_path / "meta.ini"
+        metadata = Metadata(
+            mod_id=1,
+            file_id=2,
+            version=version,
+            file_name="test.7z",
+            game_id="skyrimspecialedition",
+        )
+
+        # when
+        ModOrganizer.write_meta_ini_file(
+            meta_ini_path, metadata, GameService.get_game_by_id("skyrimse")
+        )
+
+        # then
+        meta_ini_data: IniData = IniFile.load(meta_ini_path)
+        assert meta_ini_data["General"]["version"] == expected_version
+
     def test_install_mod_with_separator(
         self, test_fs: FakeFilesystem, instance: Instance
     ) -> None:

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from base_test import BaseTest
-from cutleast_core_lib.core.utilities.ini_file import IniData, IniFile
+from cutleast_core_lib.core.utilities.ini_file import IniData, IniFile, IniValue
 from cutleast_core_lib.test.utils import Utils
 from mod_manager_lib.core.game import Game
 from mod_manager_lib.core.game_service import GameService
@@ -138,6 +138,65 @@ class TestModOrganizer(BaseTest):
         assert overwrite_mod.mod_type == Mod.Type.Overwrite
         assert overwrite_mod.files == [Path("test.txt")]
 
+    def test_modorganizer_ini_is_case_insensitive(
+        self, test_fs: FakeFilesystem, mo2_instance_info: MO2InstanceInfo
+    ) -> None:
+        """
+        Tests that `ModOrganizer.ini` sections and keys are case-insensitive.
+        """
+
+        # given
+        mo2 = ModOrganizer()
+        portable_ini_path: Path = mo2_instance_info.base_folder / "ModOrganizer.ini"
+        global_ini_path: Path = mo2.appdata_path / "Test Instance" / "ModOrganizer.ini"
+        for ini_path in [portable_ini_path, global_ini_path]:
+            ini_data: IniData = IniFile.load(ini_path)
+            lowercase_ini_data: IniData = {
+                section.casefold(): {
+                    key.casefold(): value for key, value in values.items()
+                }
+                for section, values in ini_data.items()
+            }
+            IniFile.save(ini_path, lowercase_ini_data)
+
+        # when
+        instance: Instance = mo2.load_instance(mo2_instance_info)
+        new_tool = Tool(
+            display_name="Case-insensitive tool",
+            mod=None,
+            executable=Path("C:/Tools/test.exe"),
+            commandline_args=[],
+            working_dir=None,
+            is_in_game_dir=False,
+        )
+        mo2.add_tool(
+            new_tool,
+            instance,
+            mo2_instance_info,
+            use_hardlinks=False,
+            replace=False,
+        )
+
+        # then
+        assert instance.game_folder == Path("E:/SteamLibrary/Skyrim Special Edition")
+        assert len(instance.tools) == 4
+        assert mo2.get_instance_names(mo2_instance_info.game) == ["Test Instance"]
+        assert mo2.get_profile_names(portable_ini_path) == ["Default", "TestProfile"]
+        assert mo2.get_last_active_profile(portable_ini_path) == "Default"
+
+        updated_ini_data: IniData = IniFile.load(portable_ini_path)
+        custom_executable_sections: list[str] = [
+            section
+            for section in updated_ini_data
+            if section.casefold() == "customexecutables"
+        ]
+        assert custom_executable_sections == ["customexecutables"]
+        custom_executables: dict[str, IniValue] = updated_ini_data[
+            custom_executable_sections[0]
+        ]
+        assert custom_executables["size"] == 6
+        assert custom_executables["6\\title"] == new_tool.display_name
+
     @staticmethod
     def process_conflicts_stub(mods: list[Mod], file_blacklist: list[str]) -> None:
         """
@@ -167,7 +226,9 @@ class TestModOrganizer(BaseTest):
             "test_file_3": [mods[4]],
         }
 
-        for i in range(100_000, 500_000):  # simulate a large mod list with lots of files
+        for i in range(
+            100_000, 500_000
+        ):  # simulate a large mod list with lots of files
             file_index[f"test_file_{i}"] = [mods[i // 100_000]]
 
             # add some hidden files
@@ -214,7 +275,9 @@ class TestModOrganizer(BaseTest):
 
         # then
         assert mod1_file_redirects == {}
-        assert mod2_file_redirects == {Path("test_file_2.mohidden"): Path("test_file_2")}
+        assert mod2_file_redirects == {
+            Path("test_file_2.mohidden"): Path("test_file_2")
+        }
 
     def test_create_instance(self, test_fs: FakeFilesystem) -> None:
         """

--- a/tests/core/mod_manager/modorganizer/test_api.py
+++ b/tests/core/mod_manager/modorganizer/test_api.py
@@ -380,6 +380,72 @@ class TestModOrganizer(BaseTest):
         assert migrated_overwritten_mod.files == overwritten_mod.files
         assert migrated_overwriting_mod.files == overwriting_mod.files
 
+    def test_install_root_builder_mod_splits_game_and_root_files(
+        self, test_fs: FakeFilesystem
+    ) -> None:
+        """
+        Tests Root Builder places Data files at the mod root and game files in Root.
+        """
+
+        # given
+        mo2 = ModOrganizer()
+        game = GameService.get_game_by_id("skyrimse")
+        instance_path = Path("E:/Modding/Root Builder Test")
+        instance_data = MO2InstanceInfo(
+            display_name="Root Builder Test",
+            game=game,
+            profile="Default",
+            is_global=False,
+            base_folder=instance_path,
+            mods_folder=instance_path / "mods",
+            profiles_folder=instance_path / "profiles",
+            install_mo2=False,
+            use_root_builder=True,
+        )
+        instance: Instance = mo2.create_instance(
+            instance_data, Path("E:/SteamLibrary/Skyrim Special Edition")
+        )
+        source_path = Path("C:/Source/Root Builder Mod")
+        test_fs.create_file(source_path / "meta.ini", contents="[General]\n")
+        test_fs.create_file(source_path / "skse64_loader.exe")
+        test_fs.create_file(source_path / "Data" / "Scripts" / "a.pex")
+        test_fs.create_file(source_path / "redirected" / "interface.swf")
+        test_fs.create_file(source_path / "Data" / "Scripts" / "hidden.pex.mohidden")
+        mod = Mod(
+            display_name="Root Builder Mod",
+            path=source_path,
+            deploy_path=Path("."),
+            metadata=Metadata.create_blank(),
+            installed=True,
+            enabled=True,
+        )
+        mod.file_conflicts[str(Path("Data/Scripts/hidden.pex")).lower()] = mod
+        file_redirects: dict[Path, Path] = mo2.get_actual_files(mod)
+        file_redirects[Path("redirected/interface.swf")] = Path(
+            "Data/interface/interface.swf"
+        )
+
+        # when
+        mo2.install_mod(
+            mod,
+            instance,
+            instance_data,
+            file_redirects=file_redirects,
+            use_hardlinks=False,
+            replace=True,
+        )
+
+        # then
+        mod_folder: Path = instance_data.mods_folder / mod.display_name
+        assert (mod_folder / "meta.ini").is_file()
+        assert not (mod_folder / "Root" / "meta.ini").exists()
+        assert (mod_folder / "Root" / "skse64_loader.exe").is_file()
+        assert (mod_folder / "Scripts" / "a.pex").is_file()
+        assert (mod_folder / "interface" / "interface.swf").is_file()
+        assert (mod_folder / "Scripts" / "hidden.pex.mohidden").is_file()
+        assert not (mod_folder / "Data").exists()
+        assert not (mod_folder / "Root" / "Data").exists()
+
     @pytest.mark.parametrize(
         ("version", "expected_version"),
         [

--- a/tests/core/mod_manager/vortex/test_api.py
+++ b/tests/core/mod_manager/vortex/test_api.py
@@ -347,6 +347,16 @@ class TestVortex(BaseTest):
                 "type": None,
             },
         )
+        legacy_profile_mod_data: dict[str, Any] = {
+            "enabled": False,
+            "enabledTime": 1,
+        }
+        other_profile_id = "other-profile"
+        for profile_id in (profile_info.id, other_profile_id):
+            database.set_section(
+                f"persistent###profiles###{profile_id}###modState###{legacy_id}###",
+                legacy_profile_mod_data,
+            )
         database.save()
 
         # when
@@ -370,6 +380,15 @@ class TestVortex(BaseTest):
             mods_data[vortex_id]["attributes"]["customFileName"]
             == "Existing legacy record"
         )
+        profiles_data: dict[str, Any] = database.get_section(
+            "persistent###profiles###"
+        )["persistent"]["profiles"]
+        target_mod_states: dict[str, Any] = profiles_data[profile_info.id]["modState"]
+        assert set(target_mod_states) == {vortex_id}
+        assert target_mod_states[vortex_id]["enabled"] is True
+        other_mod_states: dict[str, Any] = profiles_data[other_profile_id]["modState"]
+        assert set(other_mod_states) == {vortex_id}
+        assert other_mod_states[vortex_id] == legacy_profile_mod_data
         assert (staging_path / "existing.txt").is_file()
         assert not (staging_path / "new.txt").exists()
 

--- a/tests/core/mod_manager/vortex/test_api.py
+++ b/tests/core/mod_manager/vortex/test_api.py
@@ -144,6 +144,57 @@ class TestVortex(BaseTest):
         target_mod: Mod = self.get_mod_by_name("Wet and Cold SE - German", instance)
         assert source_mod.mod_conflicts == [target_mod]
 
+    def test_load_conflicts_skips_ambiguous_file_expression(
+        self,
+        full_vortex_db: MockPlyvelDB,
+        test_fs: FakeFilesystem,
+        vortex_profile_info: ProfileInfo,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Tests file expressions matching multiple variants are ignored."""
+
+        # given
+        source_id = "Wet and Cold SE v2.4.0-644-2-4-0-1601332084"
+        target_id = "Wet and Cold SE - Deutsch-89391-2-4-0-1716634410"
+        variant_id = f"{target_id}-alternate"
+        target_file_name = "Wet and Cold SE - Deutsch-89391-2-4-0-1716634410.zip"
+        rules_key = (f"persistent###mods###skyrimse###{source_id}###rules").encode()
+        target_prefix = f"persistent###mods###skyrimse###{target_id}###".encode()
+        variant_prefix = f"persistent###mods###skyrimse###{variant_id}###".encode()
+        raw_data: dict[bytes, bytes] = Utils.get_private_field(
+            full_vortex_db, *TestVortex.RAW_DATA
+        )
+        raw_data[rules_key] = json.dumps(
+            [
+                {
+                    "reference": {"fileExpression": target_file_name},
+                    "type": "before",
+                }
+            ]
+        ).encode()
+        for key, value in list(raw_data.items()):
+            if key.startswith(target_prefix):
+                raw_data[variant_prefix + key.removeprefix(target_prefix)] = value
+        raw_data[variant_prefix + b"id"] = json.dumps(variant_id).encode()
+        raw_data[variant_prefix + b"installationPath"] = json.dumps(variant_id).encode()
+        profile_prefix = (
+            f"persistent###profiles###{vortex_profile_info.id}###modState###"
+            f"{variant_id}###"
+        ).encode()
+        raw_data[profile_prefix + b"enabled"] = b"true"
+        test_fs.create_dir(Path("E:/Modding/Vortex/skyrimse") / variant_id)
+        vortex = Vortex()
+        vortex.db_path.mkdir(parents=True, exist_ok=True)
+
+        # when
+        instance: Instance = vortex.load_instance(vortex_profile_info)
+
+        # then
+        source_mod: Mod = self.get_mod_by_name("Wet and Cold SE", instance)
+        assert source_mod.mod_conflicts == []
+        assert "Ambiguous fileExpression" in caplog.text
+        assert target_file_name in caplog.text
+
     def test_create_instance(
         self, test_fs: FakeFilesystem, ready_vortex_db: MockPlyvelDB
     ) -> None:

--- a/tests/core/mod_manager/vortex/test_api.py
+++ b/tests/core/mod_manager/vortex/test_api.py
@@ -295,6 +295,84 @@ class TestVortex(BaseTest):
         dst_profile = vortex.load_instance(profile_info)
         assert dst_profile.mods[-1].metadata == mod.metadata
 
+    def test_install_mod_migrates_legacy_non_variant_id(
+        self, test_fs: FakeFilesystem, ready_vortex_db: MockPlyvelDB
+    ) -> None:
+        """Tests an existing raw archive ID is migrated instead of duplicated."""
+
+        # given
+        vortex = Vortex()
+        vortex.db_path.mkdir(parents=True, exist_ok=True)
+        profile_info = ProfileInfo(
+            display_name="Legacy ID test",
+            game=GameService.get_game_by_id("skyrimse"),
+            id="legacy-id-test",
+        )
+        instance: Instance = vortex.create_instance(
+            profile_info, Path("E:/SteamLibrary/Skyrim Special Edition")
+        )
+        archive_name = "Legacy: Mod.7z"
+        legacy_id = "Legacy: Mod"
+        vortex_id = "Legacy Mod"
+        staging_path = Path("E:/Modding/Vortex/skyrimse") / vortex_id
+        test_fs.create_file(staging_path / "existing.txt")
+        source_path = Path("C:/Source/Legacy Mod")
+        test_fs.create_file(source_path / "new.txt")
+        mod = Mod(
+            display_name="Legacy Mod",
+            path=source_path,
+            deploy_path=None,
+            metadata=Metadata(
+                mod_id=None,
+                file_id=None,
+                version="1.0",
+                file_name=archive_name,
+                game_id="skyrimspecialedition",
+            ),
+            installed=True,
+            enabled=True,
+        )
+        database: LevelDB = Utils.get_private_field(vortex, *TestVortex.DATABASE)
+        legacy_prefix = f"persistent###mods###skyrimse###{legacy_id}###"
+        database.set_section(
+            legacy_prefix,
+            {
+                "attributes": {
+                    "customFileName": "Existing legacy record",
+                    "fileName": archive_name,
+                },
+                "id": legacy_id,
+                "installationPath": vortex_id,
+                "state": "installed",
+                "type": None,
+            },
+        )
+        database.save()
+
+        # when
+        vortex.install_mod(
+            mod,
+            instance,
+            profile_info,
+            file_redirects={},
+            use_hardlinks=False,
+            replace=True,
+        )
+        vortex.finalize_instance(instance, profile_info, activate_instance=False)
+
+        # then
+        mods_data: dict[str, Any] = database.get_section(
+            "persistent###mods###skyrimse###"
+        )["persistent"]["mods"]["skyrimse"]
+        assert set(mods_data) == {vortex_id}
+        assert mods_data[vortex_id]["id"] == vortex_id
+        assert (
+            mods_data[vortex_id]["attributes"]["customFileName"]
+            == "Existing legacy record"
+        )
+        assert (staging_path / "existing.txt").is_file()
+        assert not (staging_path / "new.txt").exists()
+
     def test_install_and_load_mod_variants(
         self, test_fs: FakeFilesystem, ready_vortex_db: MockPlyvelDB
     ) -> None:

--- a/tests/core/mod_manager/vortex/test_api.py
+++ b/tests/core/mod_manager/vortex/test_api.py
@@ -12,6 +12,7 @@ from cutleast_core_lib.test.utils import Utils
 from mod_manager_lib.core.game import Game
 from mod_manager_lib.core.game_service import GameService
 from mod_manager_lib.core.instance.instance import Instance
+from mod_manager_lib.core.instance.metadata import Metadata
 from mod_manager_lib.core.instance.mod import Mod
 from mod_manager_lib.core.instance.tool import Tool
 from mod_manager_lib.core.mod_manager.vortex.api import Vortex
@@ -259,6 +260,96 @@ class TestVortex(BaseTest):
         # then
         dst_profile = vortex.load_instance(profile_info)
         assert dst_profile.mods[-1].metadata == mod.metadata
+
+    def test_install_and_load_mod_variants(
+        self, test_fs: FakeFilesystem, ready_vortex_db: MockPlyvelDB
+    ) -> None:
+        """
+        Tests variants installed from the same archive remain distinct in Vortex.
+        """
+
+        # given
+        vortex = Vortex()
+        vortex.db_path.mkdir(parents=True, exist_ok=True)
+        profile_info = ProfileInfo(
+            display_name="Variant test",
+            game=GameService.get_game_by_id("skyrimse"),
+            id="variant-test",
+        )
+        dst_profile: Instance = vortex.create_instance(
+            profile_info, Path("E:/SteamLibrary/Skyrim Special Edition")
+        )
+        archive_name = "Dear Diary Dark Mode-60837-1-1-1-1667594519.7z"
+        archive_id = archive_name.rsplit(".", 1)[0]
+        metadata = Metadata(
+            mod_id=60837,
+            file_id=1,
+            version="1.1.1",
+            file_name=archive_name,
+            game_id="skyrimspecialedition",
+        )
+        base_path = Path("C:/Source/Dear Diary Dark Mode")
+        variant_path = Path("C:/Source/Dear Diary Dark Mode - 21x9")
+        test_fs.create_file(base_path / "interface" / "base.txt")
+        test_fs.create_file(variant_path / "interface" / "widescreen.txt")
+        base_mod = Mod(
+            display_name="Dear Diary Dark Mode",
+            path=base_path,
+            deploy_path=None,
+            metadata=metadata,
+            installed=True,
+            enabled=True,
+        )
+        variant_mod = Mod(
+            display_name="Dear Diary Dark Mode",
+            path=variant_path,
+            deploy_path=None,
+            metadata=metadata,
+            variant="21x9",
+            installed=True,
+            enabled=False,
+        )
+        base_mod.mod_conflicts = [variant_mod]
+
+        # when
+        for mod in [base_mod, variant_mod]:
+            vortex.install_mod(
+                mod,
+                dst_profile,
+                profile_info,
+                file_redirects={},
+                use_hardlinks=False,
+                replace=True,
+            )
+        vortex.finalize_instance(dst_profile, profile_info, activate_instance=False)
+        loaded_profile: Instance = vortex.load_instance(
+            ProfileInfo(
+                display_name="Variant test (variant-test)",
+                game=profile_info.game,
+                id=profile_info.id,
+            )
+        )
+
+        # then
+        database: LevelDB = Utils.get_private_field(vortex, *TestVortex.DATABASE)
+        mods_data: dict[str, Any] = database.get_section(
+            "persistent###mods###skyrimse###"
+        )["persistent"]["mods"]["skyrimse"]
+        variant_id: str = f"{archive_id}-21x9"
+        assert set(mods_data) == {archive_id, variant_id}
+        assert mods_data[archive_id]["attributes"]["fileName"] == archive_name
+        assert mods_data[variant_id]["attributes"]["fileName"] == archive_name
+        assert (Path("E:/Modding/Vortex/skyrimse") / archive_id).is_dir()
+        assert (Path("E:/Modding/Vortex/skyrimse") / variant_id).is_dir()
+
+        loaded_base: Mod = self.get_mod_by_name("Dear Diary Dark Mode", loaded_profile)
+        loaded_variant: Mod = self.get_mod_by_name(
+            "Dear Diary Dark Mode - 21x9", loaded_profile
+        )
+        assert loaded_base.variant is None
+        assert loaded_variant.variant == "21x9"
+        assert not loaded_variant.enabled
+        assert loaded_base.mod_conflicts == [loaded_variant]
 
     def test_format_utc_timestamp(self) -> None:
         """

--- a/tests/core/mod_manager/vortex/test_api.py
+++ b/tests/core/mod_manager/vortex/test_api.py
@@ -110,6 +110,40 @@ class TestVortex(BaseTest):
         assert not dip.is_in_game_dir
         assert dip.working_dir is None
 
+    def test_load_conflicts_resolves_file_expression(
+        self,
+        full_vortex_db: MockPlyvelDB,
+        test_fs: FakeFilesystem,
+        vortex_profile_info: ProfileInfo,
+    ) -> None:
+        """Tests conflict rules containing only a file expression are resolved."""
+
+        # given
+        source_id = "Wet and Cold SE v2.4.0-644-2-4-0-1601332084"
+        target_file_name = "Wet and Cold SE - Deutsch-89391-2-4-0-1716634410.zip"
+        rules_key = (f"persistent###mods###skyrimse###{source_id}###rules").encode()
+        raw_data: dict[bytes, bytes] = Utils.get_private_field(
+            full_vortex_db, *TestVortex.RAW_DATA
+        )
+        raw_data[rules_key] = json.dumps(
+            [
+                {
+                    "reference": {"fileExpression": target_file_name},
+                    "type": "before",
+                }
+            ]
+        ).encode()
+        vortex = Vortex()
+        vortex.db_path.mkdir(parents=True, exist_ok=True)
+
+        # when
+        instance: Instance = vortex.load_instance(vortex_profile_info)
+
+        # then
+        source_mod: Mod = self.get_mod_by_name("Wet and Cold SE", instance)
+        target_mod: Mod = self.get_mod_by_name("Wet and Cold SE - German", instance)
+        assert source_mod.mod_conflicts == [target_mod]
+
     def test_create_instance(
         self, test_fs: FakeFilesystem, ready_vortex_db: MockPlyvelDB
     ) -> None:
@@ -279,8 +313,8 @@ class TestVortex(BaseTest):
         dst_profile: Instance = vortex.create_instance(
             profile_info, Path("E:/SteamLibrary/Skyrim Special Edition")
         )
-        archive_name = "Dear Diary Dark Mode-60837-1-1-1-1667594519.7z"
-        archive_id = archive_name.rsplit(".", 1)[0]
+        archive_name = "Dear Diary: Dark Mode-60837-1-1-1-1667594519.7z"
+        archive_id = "Dear Diary Dark Mode-60837-1-1-1-1667594519"
         metadata = Metadata(
             mod_id=60837,
             file_id=1,
@@ -350,6 +384,22 @@ class TestVortex(BaseTest):
         assert loaded_variant.variant == "21x9"
         assert not loaded_variant.enabled
         assert loaded_base.mod_conflicts == [loaded_variant]
+
+        # when
+        limited_profile: Instance = vortex.load_instance(
+            ProfileInfo(
+                display_name="Variant test (variant-test)",
+                game=profile_info.game,
+                id=profile_info.id,
+            ),
+            modname_limit=20,
+        )
+
+        # then
+        limited_variant: Mod = next(
+            mod for mod in limited_profile.mods if mod.variant == "21x9"
+        )
+        assert limited_variant.display_name == "Dear Diary Dark Mode - 21x9"
 
     def test_format_utc_timestamp(self) -> None:
         """

--- a/tests/core/mod_manager/vortex/test_leveldb.py
+++ b/tests/core/mod_manager/vortex/test_leveldb.py
@@ -194,6 +194,52 @@ class TestLevelDB(BaseTest):
         # then
         assert list(full_vortex_db.iterator(prefix=prefix.encode())) == []
 
+    def test_set_key_restores_key_after_section_deletion(
+        self, full_vortex_db: MockPlyvelDB
+    ) -> None:
+        """Tests set_key restores a key within a section pending deletion."""
+
+        # given
+        leveldb = LevelDB(Path(), use_symlink=False)
+        prefix = "persistent###mods###skyrimse###restored-mod###"
+        key = f"{prefix}id"
+
+        # when
+        leveldb.delete_section(prefix)
+        leveldb.set_key(key, "restored-mod")
+
+        # then
+        assert leveldb.get_key(key) == "restored-mod"
+
+        # when
+        leveldb.save()
+
+        # then
+        assert full_vortex_db.get(key.encode()) == b'"restored-mod"'
+
+    def test_set_section_restores_key_after_section_deletion(
+        self, full_vortex_db: MockPlyvelDB
+    ) -> None:
+        """Tests set_section restores keys within a section pending deletion."""
+
+        # given
+        leveldb = LevelDB(Path(), use_symlink=False)
+        prefix = "persistent###mods###skyrimse###restored-mod###"
+        key = f"{prefix}id"
+
+        # when
+        leveldb.delete_section(prefix)
+        leveldb.set_section(prefix, {"id": "restored-mod"})
+
+        # then
+        assert leveldb.get_key(key) == "restored-mod"
+
+        # when
+        leveldb.save()
+
+        # then
+        assert full_vortex_db.get(key.encode()) == b'"restored-mod"'
+
     def test_get_section_parsing(self, full_vortex_db: MockPlyvelDB) -> None:
         """
         Tests that get_section() correctly parses nested data.

--- a/tests/core/mod_manager/vortex/test_leveldb.py
+++ b/tests/core/mod_manager/vortex/test_leveldb.py
@@ -169,6 +169,31 @@ class TestLevelDB(BaseTest):
         assert full_vortex_db.get(key.encode()) == b'"v1"'
         assert Utils.get_private_field(leveldb, *TestLevelDB.CHANGES_PENDING) is False
 
+    def test_delete_section_removes_keys_on_save(
+        self, full_vortex_db: MockPlyvelDB
+    ) -> None:
+        """Tests deleting a section removes its keys from memory and storage."""
+
+        # given
+        leveldb = LevelDB(Path(), use_symlink=False)
+        prefix = (
+            "persistent###mods###skyrimse###"
+            "Obsidian Weathers - 1.07a-12125-1-07a-1620568126###"
+        )
+        assert list(full_vortex_db.iterator(prefix=prefix.encode()))
+
+        # when
+        leveldb.delete_section(prefix)
+
+        # then
+        assert leveldb.get_section(prefix) == {}
+
+        # when
+        leveldb.save()
+
+        # then
+        assert list(full_vortex_db.iterator(prefix=prefix.encode())) == []
+
     def test_get_section_parsing(self, full_vortex_db: MockPlyvelDB) -> None:
         """
         Tests that get_section() correctly parses nested data.

--- a/tests/setup/mock_plyvel.py
+++ b/tests/setup/mock_plyvel.py
@@ -37,6 +37,9 @@ class MockPlyvelDB:
     def put(self, key: bytes, value: bytes) -> None:  # noqa: D102
         self.__data[key] = value
 
+    def delete(self, key: bytes) -> None:  # noqa: D102
+        self.__data.pop(key, None)
+
     def get(self, key: bytes) -> Optional[bytes]:  # noqa: D102
         if key in self.__data:
             return self.__data[key]


### PR DESCRIPTION
## Summary

This PR fixes four MO2/Vortex migration issues while keeping the existing manager method signatures intact. It adds reliable support for differently-cased MO2 settings, normalized MO2 version metadata, multiple installations from one archive, and the correct Root Builder layout. Follow-up fixes harden Vortex identity migration, conflict resolution, and LevelDB updates.

### Mod Organizer 2

- Read `ModOrganizer.ini` sections and keys case-insensitively for instance discovery, paths, profiles, tools, and custom executables.
- Reuse existing INI sections regardless of casing when adding custom executables.
- Centralize settings-folder resolution while preserving `base_directory`, relative paths, and default-folder behavior.
- Pad versions in newly generated `meta.ini` files to four segments while preserving empty, four-or-more-part, and copied metadata values.
- Apply existing file redirects before Root Builder placement.
- Put content below the game's mods folder directly into the MO2 mod root and game-root files below `Root/`, without producing `Root/Data`.
- Keep a file whose path exactly matches the mods-folder name at the mod root.

### Installation variants

- Add the backwards-compatible optional `Mod.variant` field and preserve it in copies.
- Detect multiple MO2 mods originating from the same installation archive and assign stable variants.
- Preserve variants when loading from and installing into Vortex.
- Keep `attributes.fileName` equal to the original archive while using variant-aware database IDs, staging directories, profile states, and conflict references.
- Truncate only the base display name so long names retain the complete variant suffix.

### Vortex data integrity

- Resolve conflict references by Vortex database ID first, with a unique `fileExpression` fallback for legacy data.
- Log and skip ambiguous `fileExpression` references instead of selecting an arbitrary variant.
- Migrate legacy raw archive-stem IDs to cleaned IDs without duplicating records, including references in every Vortex profile.
- Defer LevelDB section deletions until `save()` so database access remains centralized and subsequent `set_key()` or `set_section()` calls can restore pending keys safely.

## Compatibility

- Existing `load_instance()`, `install_mod()`, `get_actual_files()`, and related manager APIs remain unchanged.
- The only public model extension is the optional `Mod.variant` field.
- No PEP 695 generic syntax is introduced.

## Validation

- `uv run --frozen ruff check src tests`
- `uv run --frozen pyright --warnings src tests`
- `uv run --frozen pytest -q` — 90 tests passed

Closes #1
Closes #2
Closes #7
Closes #8